### PR TITLE
Fix missing GetSpellInfo

### DIFF
--- a/ExecuteOverlay/ExecuteOverlay.lua
+++ b/ExecuteOverlay/ExecuteOverlay.lua
@@ -33,7 +33,8 @@ if (hunter and (class == "HUNTER")) or (mage and (class == "MAGE")) or (paladin 
                 local t = GetActiveSpecGroup()
                 local suddenDeathActive
 
-                local suddenDeathSpellName = GetSpellInfo(52437) -- Sudden Death
+                local getSpellInfo = GetSpellInfo or (C_Spell and C_Spell.GetSpellInfo)
+                local suddenDeathSpellName = (getSpellInfo and getSpellInfo(52437)) or "Sudden Death" -- Sudden Death
 
                 if AuraUtil and AuraUtil.FindAuraByName then
                         suddenDeathActive = AuraUtil.FindAuraByName(suddenDeathSpellName, "player", "HELPFUL")


### PR DESCRIPTION
## Summary
- handle missing `GetSpellInfo` gracefully in ExecuteOverlay

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875b8e48280832e9469e3b1cbf8c0d7