### PR TITLE
Fix execute overlay display

### DIFF
--- a/ExecuteOverlay/ExecuteOverlay.lua
+++ b/ExecuteOverlay/ExecuteOverlay.lua
@@ -22,7 +22,8 @@ local thresholds = {
 }
 
 local overlayTexture = "INTERFACE\\SPELLACTIVATIONOVERLAYS\\GENERICARC_05.BLP"
-local overlayID = 0
+-- use a non-zero overlay id so the activation frame properly registers the event
+local overlayID = 1
 
 local class = select(2, UnitClass("player"))
 


### PR DESCRIPTION
## Summary
- use non-zero overlay ID so overlay appears correctly

## Testing
- `luajit -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687872b3d860832e90363678c6392b3c